### PR TITLE
feat: add SEO tags for blog posts

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,203 +3,229 @@ import '../styles/global.scss';
 
 // Base domain URL without trailing slash
 const domainBaseURL = 'https://ashley.dev';
-const ogImageUrl    = `${domainBaseURL}/meta.png`;
+const ogImageUrl = `${domainBaseURL}/meta.png`;
 
 // Website publisher & region
-const authorPublisher   = 'Ashley Willis';
-const geoRegion         = 'seattle-us';
+const authorPublisher = 'Ashley Willis';
+const geoRegion = 'seattle-us';
 
 // SEO title, description and keywords
-const seoTitle          = 'Ashley Willis – ashley.dev';
-const seoDescription    = 'Developer advocate, open source champion, and maker of things.';
-const seoKeywords       = 'Developer Advocacy, Ashley Willis, Ashley McNamara, Seattle, GitHub, Golang, Kubernetes, Open Source, DevRel, Developer Relations, DevOps';
+const seoTitle = 'Ashley Willis – ashley.dev';
+const seoDescription =
+	'Developer advocate, open source champion, and maker of things.';
+const seoKeywords =
+	'Developer Advocacy, Ashley Willis, Ashley McNamara, Seattle, GitHub, Golang, Kubernetes, Open Source, DevRel, Developer Relations, DevOps';
 
 // Twitter card data
 const twitter = {
-    title:          seoTitle,
-    description:    seoDescription,
-    image:          ogImageUrl,
-    site:           '@ashleymcnamara',
-    creator:        '@ashleymcnamara'
+	title: seoTitle,
+	description: seoDescription,
+	image: ogImageUrl,
+	site: '@ashleymcnamara',
+	creator: '@ashleymcnamara',
 };
 
 // Open graph data
 const openGraph = {
-    title:          seoTitle,
-    description:    seoDescription,
-    url:            domainBaseURL,
-    image:          ogImageUrl,
-    type:           'website',
-    locale:         'en_US',
-    siteName:       'ashley.dev'
+	title: seoTitle,
+	description: seoDescription,
+	url: domainBaseURL,
+	image: ogImageUrl,
+	type: 'website',
+	locale: 'en_US',
+	siteName: 'ashley.dev',
 };
 
 // Dublin core
 const dublinCore = {
-    title:          seoTitle,
-    creator:        authorPublisher,
-    publisher:      authorPublisher,
-    rights:         authorPublisher,
-    description:    seoDescription,
-    language:       'en',
-    type:           'Software',
-    format:         'text/html'
+	title: seoTitle,
+	creator: authorPublisher,
+	publisher: authorPublisher,
+	rights: authorPublisher,
+	description: seoDescription,
+	language: 'en',
+	type: 'Software',
+	format: 'text/html',
 };
-
 ---
 
 <!doctype html>
 <html lang="en" class="bg-black text-gray-100 font-mono">
+	<head>
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVZ41CFHVX"
+		></script>
+		<script is:inline>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag('js', new Date());
+			gtag('config', 'G-SVZ41CFHVX');
+		</script>
 
-    <head>
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVZ41CFHVX"></script>
-        <script is:inline>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'G-SVZ41CFHVX');
-        </script>
+		<!-- Crawler & Robots -->
+		<meta
+			name="robots"
+			content="index, follow, noodp, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
+		/>
+		<meta name="revisit-after" content="7 days" />
+		<meta name="revisit" content="after 7 days" />
 
-        <!-- Crawler & Robots -->
-        <meta name="robots" content="index, follow, noodp, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-        <meta name="revisit-after" content="7 days" />
-        <meta name="revisit" content="after 7 days" />
+		<!-- RSS Feed -->
+		<link
+			href="/rss.xml"
+			type="application/atom+xml"
+			rel="alternate"
+			title="ashley.dev Feed"
+		/>
 
-        <!-- RSS Feed -->
-        <link href="/rss.xml" type="application/atom+xml" rel="alternate" title="ashley.dev Feed">
+		<!-- Start: Meta-Tags -->
+		<meta charset="UTF-8" />
+		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+		<meta http-equiv="Pragma" content="cache" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- End: Meta-Tags -->
 
-        <!-- Start: Meta-Tags -->
-        <meta charset="UTF-8" />
-        <meta http-equiv="content-type"         content="text/html; charset=UTF-8">
-        <meta http-equiv="Pragma"               content="cache" />
-        <meta http-equiv="X-UA-Compatible"      content="IE=edge">
-        <meta name="viewport"                   content="width=device-width, initial-scale=1">
-        <!-- End: Meta-Tags -->
+		<!-- Start: DNS prefetch and preconnect -->
+		<!-- <link rel="preload" as="image" href="/img/logo.svg" /> -->
+		<link rel="preconnect" href="https://brain.papersend.io" />
+		<!-- End: DNS prefetch and preconnect -->
 
-        <!-- Start: DNS prefetch and preconnect -->
-        <!-- <link rel="preload" as="image" href="/img/logo.svg" /> -->
-        <link rel="preconnect" href="https://brain.papersend.io" />
-        <!-- End: DNS prefetch and preconnect -->
-
-        <!-- Start: Theming and Favicons -->
-        <link rel="icon" type="image/svg+xml" crossorigin="anonymous" href="/img/logo.svg" />
-        <!-- <link rel="alternate icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
+		<!-- Start: Theming and Favicons -->
+		<link
+			rel="icon"
+			type="image/svg+xml"
+			crossorigin="anonymous"
+			href="/img/logo.svg"
+		/>
+		<!-- <link rel="alternate icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
         <link rel="alternate icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png">
         <link rel="icon" type="image/x-icon" href="/img/favicon/favicon.ico">
         <link rel="apple-touch-icon" sizes="180x180" href="/img/favicon/apple-touch-icon.png">
         <link rel="manifest" href="/img/favicon/site.webmanifest"> -->
-        <!-- End: Theming and Favicons -->
+		<!-- End: Theming and Favicons -->
 
-        <!-- Start: Misc meta tags -->
-        <link rel="sitemap"                     href="/sitemap-index.xml" />
-        <link rel="canonical"                   href={Astro.url} />
+		<!-- Start: Misc meta tags -->
+		<link rel="sitemap" href="/sitemap-index.xml" />
+		<link rel="canonical" href={Astro.url} />
 
-        <meta name="geo.region"                 content={geoRegion}>
-        <meta name="author"                     content={authorPublisher}>
-        <meta name="publisher"                  content={authorPublisher}>
-        <meta name="copyright"                  content={authorPublisher}>
-        <!-- End: Misc meta tags -->
+		<meta name="geo.region" content={geoRegion} />
+		<meta name="author" content={authorPublisher} />
+		<meta name="publisher" content={authorPublisher} />
+		<meta name="copyright" content={authorPublisher} />
+		<!-- End: Misc meta tags -->
 
-        <!-- Start: Facebook open graph -->
-        <meta property="og:title"               content={openGraph.title}>
-        <meta property="og:description"         content={openGraph.description}>
-        <meta property="og:url"                 content={openGraph.url}>
-        <meta property="og:type"                content={openGraph.type}>
-        <meta property="og:image"               content={openGraph.image}>
-        <meta property="og:locale"              content={openGraph.locale}>
-        <meta property="og:site_name"           content={openGraph.siteName}>
-        <!-- End: Facebook open graph -->
+		<slot name="head">
+			<!-- Start: Facebook open graph -->
+			<meta property="og:title" content={openGraph.title} />
+			<meta property="og:description" content={openGraph.description} />
+			<meta property="og:url" content={openGraph.url} />
+			<meta property="og:type" content={openGraph.type} />
+			<meta property="og:image" content={openGraph.image} />
+			<meta property="og:locale" content={openGraph.locale} />
+			<meta property="og:site_name" content={openGraph.siteName} />
+			<!-- End: Facebook open graph -->
 
-        <!-- Start: Twitter card -->
-        <meta name="twitter:card"               content="summary_large_image">
-        <meta name="twitter:title"              content={twitter.title}>
-        <meta name="twitter:description"        content={twitter.description}>
-        <meta name="twitter:image"              content={twitter.image}>
-        <meta name="twitter:site"               content={twitter.site}>
-        <meta name="twitter:creator"            content={twitter.creator}>
-        <!-- End: Twitter card -->
+			<!-- Start: Twitter card -->
+			<meta name="twitter:card" content="summary_large_image" />
+			<meta name="twitter:title" content={twitter.title} />
+			<meta name="twitter:description" content={twitter.description} />
+			<meta name="twitter:image" content={twitter.image} />
+			<meta name="twitter:site" content={twitter.site} />
+			<meta name="twitter:creator" content={twitter.creator} />
+			<!-- End: Twitter card -->
 
-        <!-- Start: Dublin Core (DC) -->
-        <meta name="DC.Title"                   content={dublinCore.title}>
-        <meta name="DC.Creator"                 content={dublinCore.creator}>
-        <meta name="DC.Rights"                  content={dublinCore.rights}>
-        <meta name="DC.Publisher"               content={dublinCore.publisher}>
-        <meta name="DC.Description"             content={dublinCore.description}>
-        <meta name="DC.Language"                content={dublinCore.language}>
-        <meta name="DC.Type"                    content={dublinCore.type}>
-        <meta name="DC.Format"                  content={dublinCore.format}>
-        <!-- End: Dublin Core (DC) -->
+			<!-- Start: Dublin Core (DC) -->
+			<meta name="DC.Title" content={dublinCore.title} />
+			<meta name="DC.Creator" content={dublinCore.creator} />
+			<meta name="DC.Rights" content={dublinCore.rights} />
+			<meta name="DC.Publisher" content={dublinCore.publisher} />
+			<meta name="DC.Description" content={dublinCore.description} />
+			<meta name="DC.Language" content={dublinCore.language} />
+			<meta name="DC.Type" content={dublinCore.type} />
+			<meta name="DC.Format" content={dublinCore.format} />
+			<!-- End: Dublin Core (DC) -->
 
-        <!-- Start: Structured data for better SEO -->
-        <script type="application/ld+json">
-            {
-              "@context": "https://schema.org",
-              "@type": "Person",
-              "name": "Ashley Willis",
-              "jobTitle": "Sr. Director of Developer Advocacy",
-              "url": "https://ashley.dev",
-              "sameAs": [
-                "https://github.com/ashleymcnamara",
-                "https://twitter.com/ashleymcnamara",
-                "https://www.linkedin.com/in/ashleymcnamara/"
-              ]
-            }
-        </script>
-        <!-- End: Structured data -->
+			<!-- Start: Structured data for better SEO -->
+			<script type="application/ld+json">
+				{
+					"@context": "https://schema.org",
+					"@type": "Person",
+					"name": "Ashley Willis",
+					"jobTitle": "Sr. Director of Developer Advocacy",
+					"url": "https://ashley.dev",
+					"sameAs": [
+						"https://github.com/ashleymcnamara",
+						"https://twitter.com/ashleymcnamara",
+						"https://www.linkedin.com/in/ashleymcnamara/"
+					]
+				}
+			</script>
+			<!-- End: Structured data -->
 
-        <!-- Title & Description -->
-        <title>{seoTitle}</title>
-        <meta name="description" content={seoDescription}>
-        <meta name="abstract"    content={seoDescription}>
-        <meta name="keywords"    content={seoKeywords}>
+			<!-- Title & Description -->
+			<title>{seoTitle}</title>
+			<meta name="description" content={seoDescription} />
+			<meta name="abstract" content={seoDescription} />
+			<meta name="keywords" content={seoKeywords} />
+		</slot>
 
-        <style>
-            .emoji {
-                height: 1.2em;
-                width: 1.2em;
-                vertical-align: -0.2em;
-                margin: 0 0.05em;
-            }
-            
-            /* Site layout with proper footer */
-            body {
-                min-height: 100vh;
-                display: flex;
-                flex-direction: column;
-                padding: 1rem;
-            }
-            
-            .site-content {
-                flex: 1 0 auto;
-                width: 100%;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                justify-content: center;
-            }
-            
-            .site-footer {
-                flex-shrink: 0;
-                width: 100%;
-                padding: 0.5rem 0;
-                text-align: center;
-                margin-top: 1rem;
-            }
-        </style>
+		<style>
+			.emoji {
+				height: 1.2em;
+				width: 1.2em;
+				vertical-align: -0.2em;
+				margin: 0 0.05em;
+			}
 
-    </head>
+			/* Site layout with proper footer */
+			body {
+				min-height: 100vh;
+				display: flex;
+				flex-direction: column;
+				padding: 1rem;
+			}
 
-    <body>
-        <!-- Main content wrapper -->
-        <div class="site-content">
-            <slot />
-        </div>
-        
-        <!-- Global footer -->
-        <footer class="site-footer">
-            Built with <a href="https://astro.build" title="Astro" target="_blank" class="text-primary hover:underline">Astro</a> by <a href="https://ashley.dev/" target="_blank" title="ashley.dev" class="text-primary hover:underline">ashley.dev</a>
-        </footer>
-    </body>
+			.site-content {
+				flex: 1 0 auto;
+				width: 100%;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+			}
 
+			.site-footer {
+				flex-shrink: 0;
+				width: 100%;
+				padding: 0.5rem 0;
+				text-align: center;
+				margin-top: 1rem;
+			}
+		</style>
+	</head>
+
+	<body>
+		<!-- Main content wrapper -->
+		<div class="site-content">
+			<slot />
+		</div>
+
+		<!-- Global footer -->
+		<footer class="site-footer">
+			Built with <a
+				href="https://astro.build"
+				title="Astro"
+				target="_blank"
+				class="text-primary hover:underline">Astro</a
+			> by <a
+				href="https://ashley.dev/"
+				target="_blank"
+				title="ashley.dev"
+				class="text-primary hover:underline">ashley.dev</a
+			>
+		</footer>
+	</body>
 </html>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -6,12 +6,12 @@ import BlueskyLikes from '../../components/BlueskyLikes.astro';
 
 // Generate static paths for all posts
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('posts');
-  
-  return blogEntries.map((entry: CollectionEntry<'posts'>) => ({
-    params: { slug: entry.slug },
-    props: { entry },
-  }));
+	const blogEntries = await getCollection('posts');
+
+	return blogEntries.map((entry: CollectionEntry<'posts'>) => ({
+		params: { slug: entry.slug },
+		props: { entry },
+	}));
 }
 
 // The entry prop is passed from getStaticPaths
@@ -21,634 +21,751 @@ const { Content } = await entry.render();
 // Safely handle the date
 let formattedDate;
 try {
-  formattedDate = new Date(entry.data.date).toLocaleDateString('en-US', {
-    year: 'numeric', month: 'long', day: 'numeric'
-  });
+	formattedDate = new Date(entry.data.date).toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
 } catch (e) {
-  formattedDate = "Publication date unavailable";
-  console.error("Error formatting date:", e);
+	formattedDate = 'Publication date unavailable';
+	console.error('Error formatting date:', e);
 }
 
 // Calculate reading time
 function calculateReadingTime(content) {
-  // Get the content as plain text - rough approximation
-  const text = content.toString();
-  
-  // Count words (split by space)
-  const words = text.split(/\s+/).filter(Boolean).length;
-  
-  // Average reading speed is ~200-250 words per minute
-  const wordsPerMinute = 225;
-  const minutes = Math.ceil(words / wordsPerMinute);
-  
-  return minutes;
+	// Get the content as plain text - rough approximation
+	const text = content.toString();
+
+	// Count words (split by space)
+	const words = text.split(/\s+/).filter(Boolean).length;
+
+	// Average reading speed is ~200-250 words per minute
+	const wordsPerMinute = 225;
+	const minutes = Math.ceil(words / wordsPerMinute);
+
+	return minutes;
 }
 const readingTime = calculateReadingTime(entry.body);
 
 // Check if Bluesky URI is valid
-const hasBlueskyURI = entry.data.blueskyPostURI && typeof entry.data.blueskyPostURI === 'string' && entry.data.blueskyPostURI.trim() !== '';
+const hasBlueskyURI =
+	entry.data.blueskyPostURI &&
+	typeof entry.data.blueskyPostURI === 'string' &&
+	entry.data.blueskyPostURI.trim() !== '';
 ---
 
 <Layout title={entry.data.title}>
-  <!-- Reading Progress Bar -->
-  <div id="progress-bar" class="reading-progress-bar"></div>
+	<Fragment slot="head">
+		<!-- Start: Facebook open graph -->
+		<meta property="og:title" content={entry.data.title} />
+		<meta property="og:url" content={Astro.url} />
+		<meta property="og:type" content="article" />
+		<!-- <meta property="og:image" content={openGraph.image} /> -->
+		<meta property="og:locale" content="en_US" />
+		<meta property="og:site_name" content="ashley.dev" />
+		<!-- End: Facebook open graph -->
 
-  <!-- Start: Main Wrapper -->
-  <main class="flex flex-col w-full max-w-full md:max-w-7xl border border-gray-600 rounded-2xl overflow-hidden shadow-2xl relative bg-black mb-6 mx-auto blog-post">
-    
-    <!-- Start: Content Area -->
-    <div class="w-full p-0">
-      <!-- Start: Inner wrapper -->
-      <div class="min-h-full flex flex-col">
-        
-        <!-- Start: Header bar (similar to the tab bar in home) -->
-        <div class="flex flex-col bg-black border-b border-gray-600 sticky top-0 z-10 p-4 backdrop-blur-md bg-opacity-90">
-          <div class="flex-grow">
-            <a href="/blog" class="px-4 py-2.5 border border-gray-600 rounded-lg hover:text-primary hover:border-primary transition-all duration-300 inline-block mb-4 back-button">
-              &larr; Back to Blog
-            </a>
-            <h1 class="text-3xl md:text-4xl font-bold post-title">{entry.data.title}</h1>
-          </div>
-        </div>
-        <!-- End: Header bar -->
+		<!-- Start: Twitter card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={entry.data.title} />
+		<!-- <meta name="twitter:image" content={twitter.image} /> -->
+		<meta name="twitter:site" content="@ashleymacnamara" />
+		<meta name="twitter:creator" content="@ashleymacnamara" />
+		<!-- End: Twitter card -->
 
-        <!-- Start: Post content -->
-        <div class="p-6 flex-grow overflow-y-auto bg-black">
-          <article>
-            <div class="flex flex-wrap items-center gap-3 mb-8 meta-info">
-              <p class="text-gray-400">{formattedDate}</p>
-              
-              <!-- Reading Time -->
-              <p class="text-gray-400 flex items-center">
-                <span class="inline-block mr-1">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </span>
-                {readingTime} min read
-              </p>
-              
-              <!-- Tags display -->
-              <div class="flex flex-wrap gap-2">
-                {entry.data.tags?.map((tag: string) => (
-                  <span class="inline-flex items-center justify-center px-3 py-1 text-xs rounded-full bg-black text-gray-100 cursor-pointer transition-all duration-300 border border-gray-600 hover:bg-primary hover:-translate-y-1 hover:text-white tag-link" data-tag={tag}>
-                    #{tag}
-                  </span>
-                ))}
-              </div>
-            </div>
-            
-            <div class="prose prose-invert max-w-none post-content">
-              <Content />
-            </div>
-            
-            <!-- Bluesky Likes Component -->
-            {hasBlueskyURI && (
-              <div class="bluesky-component-wrapper">
-                <BlueskyLikes blueskyPostURI={entry.data.blueskyPostURI} />
-              </div>
-            )}
-          </article>
-        </div>
-        <!-- End: Post content -->
-        
-      </div>
-      <!-- End: Inner wrapper -->
-    </div>
-    <!-- End: Content Area -->
-    
-  </main>
-  <!-- End: Main Wrapper -->
-  
+		<!-- Start: Dublin Core (DC) -->
+		<meta name="DC.Title" content={entry.data.title} />
+
+		<!-- TODO: update for blog posts
+			<meta name="DC.Creator" content={dublinCore.creator} />
+			<meta name="DC.Rights" content={dublinCore.rights} />
+			<meta name="DC.Publisher" content={dublinCore.publisher} />
+			<meta name="DC.Description" content={dublinCore.description} />
+			<meta name="DC.Language" content={dublinCore.language} />
+			<meta name="DC.Type" content={dublinCore.type} />
+			<meta name="DC.Format" content={dublinCore.format} /> -->
+		<!-- End: Dublin Core (DC) -->
+
+		<!-- Start: Structured data for better SEO -->
+		<script
+			type="application/ld+json"
+			set:html={`
+				{
+					"@context": "https://schema.org",
+					"@type": "NewsArticle",
+					"headline": "${entry.data.title}",
+					"datePublished": "${new Date(entry.data.date).toISOString()}",
+					"dateModified": "${new Date(entry.data.date).toISOString()}",
+					"author": [{
+						"@type": "Person",
+						"name": "Ashley Willis",
+						"jobTitle": "Sr. Director of Developer Advocacy",
+						"url": "https://ashley.dev",
+						"sameAs": [
+							"https://github.com/ashleymcnamara",
+							"https://twitter.com/ashleymcnamara",
+							"https://www.linkedin.com/in/ashleymcnamara/"
+						]
+					}]
+				}
+			`}
+		/>
+		<!-- End: Structured data -->
+
+		<!-- Title & Description -->
+		<title>{entry.data.title}</title>
+		<meta name="keywords" content={entry.data.tags} />
+	</Fragment>
+
+	<!-- Reading Progress Bar -->
+	<div id="progress-bar" class="reading-progress-bar"></div>
+
+	<!-- Start: Main Wrapper -->
+	<main
+		class="flex flex-col w-full max-w-full md:max-w-7xl border border-gray-600 rounded-2xl overflow-hidden shadow-2xl relative bg-black mb-6 mx-auto blog-post"
+	>
+		<!-- Start: Content Area -->
+		<div class="w-full p-0">
+			<!-- Start: Inner wrapper -->
+			<div class="min-h-full flex flex-col">
+				<!-- Start: Header bar (similar to the tab bar in home) -->
+				<div
+					class="flex flex-col bg-black border-b border-gray-600 sticky top-0 z-10 p-4 backdrop-blur-md bg-opacity-90"
+				>
+					<div class="flex-grow">
+						<a
+							href="/blog"
+							class="px-4 py-2.5 border border-gray-600 rounded-lg hover:text-primary hover:border-primary transition-all duration-300 inline-block mb-4 back-button"
+						>
+							&larr; Back to Blog
+						</a>
+						<h1 class="text-3xl md:text-4xl font-bold post-title">
+							{entry.data.title}
+						</h1>
+					</div>
+				</div>
+				<!-- End: Header bar -->
+
+				<!-- Start: Post content -->
+				<div class="p-6 flex-grow overflow-y-auto bg-black">
+					<article>
+						<div class="flex flex-wrap items-center gap-3 mb-8 meta-info">
+							<p class="text-gray-400">{formattedDate}</p>
+
+							<!-- Reading Time -->
+							<p class="text-gray-400 flex items-center">
+								<span class="inline-block mr-1">
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										class="h-4 w-4"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+									</svg>
+								</span>
+								{readingTime} min read
+							</p>
+
+							<!-- Tags display -->
+							<div class="flex flex-wrap gap-2">
+								{
+									entry.data.tags?.map((tag: string) => (
+										<span
+											class="inline-flex items-center justify-center px-3 py-1 text-xs rounded-full bg-black text-gray-100 cursor-pointer transition-all duration-300 border border-gray-600 hover:bg-primary hover:-translate-y-1 hover:text-white tag-link"
+											data-tag={tag}
+										>
+											#{tag}
+										</span>
+									))
+								}
+							</div>
+						</div>
+
+						<div class="prose prose-invert max-w-none post-content">
+							<Content />
+						</div>
+
+						<!-- Bluesky Likes Component -->
+						{
+							hasBlueskyURI && (
+								<div class="bluesky-component-wrapper">
+									<BlueskyLikes blueskyPostURI={entry.data.blueskyPostURI} />
+								</div>
+							)
+						}
+					</article>
+				</div>
+				<!-- End: Post content -->
+			</div>
+			<!-- End: Inner wrapper -->
+		</div>
+		<!-- End: Content Area -->
+	</main>
+	<!-- End: Main Wrapper -->
 </Layout>
 
 <script>
-  // Make tag spans clickable to filter
-  document.addEventListener('DOMContentLoaded', () => {
-    // Reading progress bar functionality
-    const progressBar = document.getElementById('progress-bar');
-    let totalHeight = document.body.scrollHeight - window.innerHeight;
-    
-    // Recalculate height on window resize
-    window.addEventListener('resize', () => {
-      totalHeight = document.body.scrollHeight - window.innerHeight;
-    });
-    
-    // Recalculate after images and other resources load
-    window.addEventListener('load', () => {
-      totalHeight = document.body.scrollHeight - window.innerHeight;
-    });
-    
-    window.addEventListener('scroll', () => {
-      // Make sure we have the most accurate height measurement
-      const currentHeight = document.body.scrollHeight - window.innerHeight;
-      if (currentHeight !== totalHeight) {
-        totalHeight = currentHeight;
-      }
-      
-      const progress = Math.min((window.scrollY / totalHeight) * 100, 100);
-      if (progressBar) progressBar.style.width = `${progress}%`;
-    });
-    
-    // Add click listeners to the Table of Contents links for smooth scrolling
-    const tocLinks = document.querySelectorAll('.toc-link');
-    tocLinks.forEach(link => {
-      link.addEventListener('click', (e) => {
-        e.preventDefault();
-        const targetId = link.getAttribute('href');
-        if (targetId && targetId.startsWith('#')) {
-          const targetElement = document.querySelector(targetId);
-          if (targetElement) {
-            // Smooth scroll to the target element
-            targetElement.scrollIntoView({
-              behavior: 'smooth',
-              block: 'start'
-            });
-            
-            // Update the URL hash without jumping
-            history.pushState(null, null, targetId);
-          }
-        }
-      });
-    });
-    
-    // Handle anchor links in headings
-    const anchorLinks = document.querySelectorAll('.anchor-link');
-    anchorLinks.forEach(link => {
-      link.addEventListener('click', (e) => {
-        // Prevent the default jump
-        e.preventDefault();
-        
-        // Get the href attribute
-        const targetId = link.getAttribute('href');
-        
-        if (targetId) {
-          // Update the URL with the hash without jumping
-          history.pushState(null, null, targetId);
-          
-          // Copy the link to clipboard
-          navigator.clipboard.writeText(window.location.href)
-            .then(() => {
-              // Show a small toast notification
-              const toast = document.createElement('div');
-              toast.textContent = 'Link copied to clipboard!';
-              toast.style.position = 'fixed';
-              toast.style.bottom = '20px';
-              toast.style.right = '20px';
-              toast.style.background = 'rgba(0, 0, 0, 0.8)';
-              toast.style.color = 'white';
-              toast.style.padding = '10px 15px';
-              toast.style.borderRadius = '4px';
-              toast.style.zIndex = '9999';
-              toast.style.animation = 'fadeIn 0.3s, fadeOut 0.3s 2s forwards';
-              
-              document.body.appendChild(toast);
-              
-              // Remove the toast after 2.5 seconds
-              setTimeout(() => {
-                document.body.removeChild(toast);
-              }, 2500);
-            })
-            .catch(err => {
-              console.error('Could not copy link: ', err);
-            });
-        }
-      });
-      
-      // Make anchor link visible on hover of parent heading
-      const parentHeading = link.closest('h1, h2, h3, h4, h5, h6');
-      if (parentHeading) {
-        parentHeading.addEventListener('mouseenter', () => {
-          link.classList.add('visible');
-        });
-        
-        parentHeading.addEventListener('mouseleave', () => {
-          link.classList.remove('visible');
-        });
-      }
-    });
-    
-    const tagLinks = document.querySelectorAll('.tag-link');
-    
-    tagLinks.forEach(link => {
-      link.addEventListener('click', () => {
-        // Extract tag name from the data attribute
-        const tagName = link.getAttribute('data-tag');
-        
-        // Navigate to blog page with tag as query parameter
-        window.location.href = `/blog?tag=${tagName}`;
-      });
-    });
-    
-    // Add functionality for the back button to remember which referrer it came from
-    const backButton = document.querySelector('a[href="/blog"]') as HTMLAnchorElement;
-    if (backButton) {
-      const referrer = document.referrer;
-      
-      // Check if the referrer is from our own site and extract the path
-      if (referrer) {
-        try {
-          const referrerURL = new URL(referrer);
-          if (referrerURL.pathname === '/speaking') {
-            backButton.href = '/speaking';
-            backButton.textContent = '← Back to Speaking';
-          } else if (referrerURL.pathname === '/projects') {
-            backButton.href = '/projects';
-            backButton.textContent = '← Back to Projects';
-          }
-        } catch (e) {
-          console.error("Error parsing referrer URL:", e);
-        }
-      }
-    }
-    
-    // Force all links in blog content to be the primary color
-    const primaryColor = getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() || '#F43F5E';
-    const postLinks = document.querySelectorAll('.post-content a, .prose a');
-    
-    postLinks.forEach(link => {
-      link.style.color = primaryColor;
-      link.style.textDecoration = 'none';
-      
-      // Add event listener to recreate the hover effect from CSS
-      link.addEventListener('mouseenter', (e) => {
-        const target = e.target as HTMLElement;
-        target.style.opacity = '0.9';
-      });
-      
-      link.addEventListener('mouseleave', (e) => {
-        const target = e.target as HTMLElement;
-        target.style.opacity = '1';
-      });
-    });
-    
-    // DIRECT STYLING FOR HEADINGS: Force all headings to be pink
-    const allHeadings = document.querySelectorAll('.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6');
-    allHeadings.forEach(heading => {
-      (heading as HTMLElement).style.color = primaryColor;
-    });
-    
-    // Set up a mutation observer to handle dynamically loaded content
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.type === 'childList') {
-          const newHeadings = document.querySelectorAll('.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6');
-          newHeadings.forEach(heading => {
-            (heading as HTMLElement).style.color = primaryColor;
-          });
-        }
-      });
-    });
-    
-    // Start observing the document with the configured parameters
-    observer.observe(document.body, { childList: true, subtree: true });
-  });
+	// Make tag spans clickable to filter
+	document.addEventListener('DOMContentLoaded', () => {
+		// Reading progress bar functionality
+		const progressBar = document.getElementById('progress-bar');
+		let totalHeight = document.body.scrollHeight - window.innerHeight;
+
+		// Recalculate height on window resize
+		window.addEventListener('resize', () => {
+			totalHeight = document.body.scrollHeight - window.innerHeight;
+		});
+
+		// Recalculate after images and other resources load
+		window.addEventListener('load', () => {
+			totalHeight = document.body.scrollHeight - window.innerHeight;
+		});
+
+		window.addEventListener('scroll', () => {
+			// Make sure we have the most accurate height measurement
+			const currentHeight = document.body.scrollHeight - window.innerHeight;
+			if (currentHeight !== totalHeight) {
+				totalHeight = currentHeight;
+			}
+
+			const progress = Math.min((window.scrollY / totalHeight) * 100, 100);
+			if (progressBar) progressBar.style.width = `${progress}%`;
+		});
+
+		// Add click listeners to the Table of Contents links for smooth scrolling
+		const tocLinks = document.querySelectorAll('.toc-link');
+		tocLinks.forEach((link) => {
+			link.addEventListener('click', (e) => {
+				e.preventDefault();
+				const targetId = link.getAttribute('href');
+				if (targetId && targetId.startsWith('#')) {
+					const targetElement = document.querySelector(targetId);
+					if (targetElement) {
+						// Smooth scroll to the target element
+						targetElement.scrollIntoView({
+							behavior: 'smooth',
+							block: 'start',
+						});
+
+						// Update the URL hash without jumping
+						history.pushState(null, null, targetId);
+					}
+				}
+			});
+		});
+
+		// Handle anchor links in headings
+		const anchorLinks = document.querySelectorAll('.anchor-link');
+		anchorLinks.forEach((link) => {
+			link.addEventListener('click', (e) => {
+				// Prevent the default jump
+				e.preventDefault();
+
+				// Get the href attribute
+				const targetId = link.getAttribute('href');
+
+				if (targetId) {
+					// Update the URL with the hash without jumping
+					history.pushState(null, null, targetId);
+
+					// Copy the link to clipboard
+					navigator.clipboard
+						.writeText(window.location.href)
+						.then(() => {
+							// Show a small toast notification
+							const toast = document.createElement('div');
+							toast.textContent = 'Link copied to clipboard!';
+							toast.style.position = 'fixed';
+							toast.style.bottom = '20px';
+							toast.style.right = '20px';
+							toast.style.background = 'rgba(0, 0, 0, 0.8)';
+							toast.style.color = 'white';
+							toast.style.padding = '10px 15px';
+							toast.style.borderRadius = '4px';
+							toast.style.zIndex = '9999';
+							toast.style.animation = 'fadeIn 0.3s, fadeOut 0.3s 2s forwards';
+
+							document.body.appendChild(toast);
+
+							// Remove the toast after 2.5 seconds
+							setTimeout(() => {
+								document.body.removeChild(toast);
+							}, 2500);
+						})
+						.catch((err) => {
+							console.error('Could not copy link: ', err);
+						});
+				}
+			});
+
+			// Make anchor link visible on hover of parent heading
+			const parentHeading = link.closest('h1, h2, h3, h4, h5, h6');
+			if (parentHeading) {
+				parentHeading.addEventListener('mouseenter', () => {
+					link.classList.add('visible');
+				});
+
+				parentHeading.addEventListener('mouseleave', () => {
+					link.classList.remove('visible');
+				});
+			}
+		});
+
+		const tagLinks = document.querySelectorAll('.tag-link');
+
+		tagLinks.forEach((link) => {
+			link.addEventListener('click', () => {
+				// Extract tag name from the data attribute
+				const tagName = link.getAttribute('data-tag');
+
+				// Navigate to blog page with tag as query parameter
+				window.location.href = `/blog?tag=${tagName}`;
+			});
+		});
+
+		// Add functionality for the back button to remember which referrer it came from
+		const backButton = document.querySelector(
+			'a[href="/blog"]',
+		) as HTMLAnchorElement;
+		if (backButton) {
+			const referrer = document.referrer;
+
+			// Check if the referrer is from our own site and extract the path
+			if (referrer) {
+				try {
+					const referrerURL = new URL(referrer);
+					if (referrerURL.pathname === '/speaking') {
+						backButton.href = '/speaking';
+						backButton.textContent = '← Back to Speaking';
+					} else if (referrerURL.pathname === '/projects') {
+						backButton.href = '/projects';
+						backButton.textContent = '← Back to Projects';
+					}
+				} catch (e) {
+					console.error('Error parsing referrer URL:', e);
+				}
+			}
+		}
+
+		// Force all links in blog content to be the primary color
+		const primaryColor =
+			getComputedStyle(document.documentElement)
+				.getPropertyValue('--color-primary')
+				.trim() || '#F43F5E';
+		const postLinks = document.querySelectorAll('.post-content a, .prose a');
+
+		postLinks.forEach((link) => {
+			link.style.color = primaryColor;
+			link.style.textDecoration = 'none';
+
+			// Add event listener to recreate the hover effect from CSS
+			link.addEventListener('mouseenter', (e) => {
+				const target = e.target as HTMLElement;
+				target.style.opacity = '0.9';
+			});
+
+			link.addEventListener('mouseleave', (e) => {
+				const target = e.target as HTMLElement;
+				target.style.opacity = '1';
+			});
+		});
+
+		// DIRECT STYLING FOR HEADINGS: Force all headings to be pink
+		const allHeadings = document.querySelectorAll(
+			'.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6',
+		);
+		allHeadings.forEach((heading) => {
+			(heading as HTMLElement).style.color = primaryColor;
+		});
+
+		// Set up a mutation observer to handle dynamically loaded content
+		const observer = new MutationObserver((mutations) => {
+			mutations.forEach((mutation) => {
+				if (mutation.type === 'childList') {
+					const newHeadings = document.querySelectorAll(
+						'.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6',
+					);
+					newHeadings.forEach((heading) => {
+						(heading as HTMLElement).style.color = primaryColor;
+					});
+				}
+			});
+		});
+
+		// Start observing the document with the configured parameters
+		observer.observe(document.body, { childList: true, subtree: true });
+	});
 </script>
 
 <style>
-  /* Reading progress bar */
-  .reading-progress-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 3px;
-    background-color: var(--color-primary, #F43F5E);
-    width: 0%;
-    z-index: 100;
-    transition: width 0.1s ease;
-  }
-  
-  /* Enhanced styling for blog content */
-  .blog-post {
-    transition: all 0.3s ease-in-out;
-  }
-  
-  .post-title {
-    color: var(--color-primary, #F43F5E);
-    line-height: 1.3;
-    letter-spacing: -0.01em;
-    margin-bottom: 0.5rem;
-  }
-  
-  .back-button {
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  }
-  
-  .meta-info {
-    border-bottom: 1px solid rgba(107, 114, 128, 0.2);
-    padding-bottom: 1.5rem;
-  }
-  
-  .post-content {
-    color: #f8f8f8;
-    font-size: 1.05rem;
-    line-height: 1.8;
-    letter-spacing: 0.01em;
-  }
-  
-  .post-content p {
-    margin-bottom: 1.5rem;
-  }
-  
-  /* Strengthened link selectors to override any potential conflicts */
-  .prose a,
-  .prose a:link,
-  .prose a:visited,
-  article .prose p a,
-  .post-content .prose a {
-    color: var(--color-primary, #F43F5E) !important;
-    text-decoration: none;
-    position: relative;
-    transition: all 0.2s ease;
-  }
-  
-  .prose a:hover {
-    text-decoration: none;
-    color: var(--color-primary, #F43F5E);
-    opacity: 0.9;
-  }
-  
-  .prose a::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    transform: scaleX(0);
-    height: 1px;
-    bottom: 0;
-    left: 0;
-    background-color: var(--color-primary, #F43F5E);
-    transform-origin: bottom right;
-    transition: transform 0.25s ease-out;
-  }
-  
-  .prose a:hover::after {
-    transform: scaleX(1);
-    transform-origin: bottom left;
-  }
-  
-  .prose img {
-    border-radius: 0.75rem;
-    margin: 2rem 0;
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    transition: transform 0.3s ease;
-  }
-  
-  .prose img:hover {
-    transform: scale(1.01);
-  }
-  
-  .prose code {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 0.25rem;
-    padding: 0.2rem 0.4rem;
-    font-size: 0.9em;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  .prose pre {
-    padding: 1.25rem !important;
-    border-radius: 0.5rem !important;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    margin: 1.5rem 0 !important;
-    overflow-x: auto;
-  }
-  
-  .prose blockquote {
-    border-left: 4px solid var(--color-primary, #F43F5E);
-    padding-left: 1rem;
-    font-style: italic;
-    margin: 1.5rem 0;
-    color: #d1d5db;
-    background: rgba(255, 255, 255, 0.05);
-    padding: 1rem;
-    border-radius: 0.25rem;
-  }
-  
-  /* Strengthened selectors for headings to override Tailwind prose defaults */
-  .prose h1, 
-  .prose h2, 
-  .prose h3, 
-  .prose h4,
-  .post-content h1,
-  .post-content h2,
-  .post-content h3,
-  .post-content h4,
-  article .prose h1,
-  article .prose h2,
-  article .prose h3,
-  article .prose h4 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    line-height: 1.3;
-    font-weight: 700;
-    color: var(--color-primary, #F43F5E) !important; /* Added !important to ensure override */
-  }
-  
-  .prose h1,
-  .post-content h1 {
-    font-size: 2em;
-    margin-top: 0;
-  }
-  
-  .prose h2,
-  .post-content h2 {
-    font-size: 1.7em;
-  }
-  
-  .prose h3,
-  .post-content h3 {
-    font-size: 1.4em;
-  }
-  
-  .prose h4 {
-    font-size: 1.2em;
-  }
-  
-  /* Add subtle reveal animation when the page loads */
-  @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-  
-  .post-content {
-    animation: fadeIn 0.6s ease-out;
-  }
+	/* Reading progress bar */
+	.reading-progress-bar {
+		position: fixed;
+		top: 0;
+		left: 0;
+		height: 3px;
+		background-color: var(--color-primary, #f43f5e);
+		width: 0%;
+		z-index: 100;
+		transition: width 0.1s ease;
+	}
 
-  /* Table of Contents Styles */
-  .toc-container {
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 0.5rem;
-    padding: 1.5rem;
-    margin: 2rem 0;
-    position: relative;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  }
-  
-  .toc-title {
-    font-size: 1.3rem !important;
-    margin-top: 0 !important;
-    margin-bottom: 1rem !important;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-  }
-  
-  .toc-title::before {
-    content: '';
-    display: inline-block;
-    width: 1.2rem;
-    height: 1.2rem;
-    margin-right: 0.5rem;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23F43F5E'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 6h16M4 12h16M4 18h7'%3E%3C/path%3E%3C/svg%3E");
-    background-size: contain;
-    background-repeat: no-repeat;
-  }
-  
-  .toc-list {
-    list-style-type: none;
-    padding-left: 0;
-    margin: 0;
-  }
-  
-  .toc-item {
-    margin: 0.5rem 0;
-    transition: transform 0.2s ease;
-  }
-  
-  .toc-item-h3 {
-    padding-left: 1.5rem;
-    font-size: 0.95em;
-    opacity: 0.9;
-  }
-  
-  .toc-link {
-    color: #d1d5db !important;
-    text-decoration: none !important;
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    transition: all 0.2s ease;
-  }
-  
-  .toc-link:hover {
-    color: var(--color-primary, #F43F5E) !important;
-    transform: translateX(3px);
-  }
-  
-  .toc-link:hover::after {
-    display: none; /* Disable the underline animation for TOC links */
-  }
-  
-  .toc-link::before {
-    content: '';
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background-color: var(--color-primary, #F43F5E);
-    margin-right: 0.5rem;
-    transform: scale(0);
-    transition: transform 0.2s ease;
-  }
-  
-  .toc-link:hover::before {
-    transform: scale(1);
-  }
-  
-  /* Anchor link styles */
-  .anchor-link {
-    margin-left: 0.5rem;
-    opacity: 0;
-    font-size: 0.8em;
-    transition: opacity 0.2s ease;
-    text-decoration: none !important;
-    color: var(--color-primary, #F43F5E) !important;
-  }
-  
-  .heading-custom:hover .anchor-link,
-  .anchor-link.visible {
-    opacity: 0.7;
-  }
-  
-  .anchor-link:hover {
-    opacity: 1 !important;
-  }
-  
-  .anchor-icon {
-    display: inline-block;
-    vertical-align: middle;
-  }
-  
-  /* Callout box styles for important content */
-  .callout {
-    border-left: 4px solid var(--color-primary, #F43F5E);
-    background: rgba(255, 255, 255, 0.05);
-    padding: 1.5rem;
-    margin: 2rem 0;
-    border-radius: 0.5rem;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  }
-  
-  .callout-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: var(--color-primary, #F43F5E);
-    display: flex;
-    align-items: center;
-  }
-  
-  .callout-icon {
-    margin-right: 0.5rem;
-  }
-  
-  /* Image caption styles */
-  figure {
-    margin: 2rem 0;
-  }
-  
-  figcaption {
-    text-align: center;
-    font-style: italic;
-    color: #d1d5db;
-    font-size: 0.9em;
-    margin-top: 0.75rem;
-    opacity: 0.8;
-  }
-  
-  /* Footnote styles */
-  .footnotes {
-    margin-top: 4rem;
-    padding-top: 2rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  .footnote-backref {
-    text-decoration: none !important;
-    margin-left: 0.5rem;
-  }
-  
-  /* Code block line numbers */
-  pre {
-    counter-reset: line;
-  }
-  
-  pre span.line {
-    display: inline-block;
-    width: 100%;
-  }
-  
-  pre span.line::before {
-    counter-increment: line;
-    content: counter(line);
-    display: inline-block;
-    width: 1.5rem;
-    margin-right: 1rem;
-    text-align: right;
-    color: rgba(255, 255, 255, 0.4);
-    user-select: none;
-  }
+	/* Enhanced styling for blog content */
+	.blog-post {
+		transition: all 0.3s ease-in-out;
+	}
+
+	.post-title {
+		color: var(--color-primary, #f43f5e);
+		line-height: 1.3;
+		letter-spacing: -0.01em;
+		margin-bottom: 0.5rem;
+	}
+
+	.back-button {
+		font-weight: 500;
+		letter-spacing: 0.02em;
+		box-shadow:
+			0 4px 6px -1px rgba(0, 0, 0, 0.1),
+			0 2px 4px -1px rgba(0, 0, 0, 0.06);
+	}
+
+	.meta-info {
+		border-bottom: 1px solid rgba(107, 114, 128, 0.2);
+		padding-bottom: 1.5rem;
+	}
+
+	.post-content {
+		color: #f8f8f8;
+		font-size: 1.05rem;
+		line-height: 1.8;
+		letter-spacing: 0.01em;
+	}
+
+	.post-content p {
+		margin-bottom: 1.5rem;
+	}
+
+	/* Strengthened link selectors to override any potential conflicts */
+	.prose a,
+	.prose a:link,
+	.prose a:visited,
+	article .prose p a,
+	.post-content .prose a {
+		color: var(--color-primary, #f43f5e) !important;
+		text-decoration: none;
+		position: relative;
+		transition: all 0.2s ease;
+	}
+
+	.prose a:hover {
+		text-decoration: none;
+		color: var(--color-primary, #f43f5e);
+		opacity: 0.9;
+	}
+
+	.prose a::after {
+		content: '';
+		position: absolute;
+		width: 100%;
+		transform: scaleX(0);
+		height: 1px;
+		bottom: 0;
+		left: 0;
+		background-color: var(--color-primary, #f43f5e);
+		transform-origin: bottom right;
+		transition: transform 0.25s ease-out;
+	}
+
+	.prose a:hover::after {
+		transform: scaleX(1);
+		transform-origin: bottom left;
+	}
+
+	.prose img {
+		border-radius: 0.75rem;
+		margin: 2rem 0;
+		box-shadow:
+			0 10px 15px -3px rgba(0, 0, 0, 0.1),
+			0 4px 6px -2px rgba(0, 0, 0, 0.05);
+		transition: transform 0.3s ease;
+	}
+
+	.prose img:hover {
+		transform: scale(1.01);
+	}
+
+	.prose code {
+		background: rgba(255, 255, 255, 0.1);
+		border-radius: 0.25rem;
+		padding: 0.2rem 0.4rem;
+		font-size: 0.9em;
+		border: 1px solid rgba(255, 255, 255, 0.1);
+	}
+
+	.prose pre {
+		padding: 1.25rem !important;
+		border-radius: 0.5rem !important;
+		box-shadow:
+			0 4px 6px -1px rgba(0, 0, 0, 0.1),
+			0 2px 4px -1px rgba(0, 0, 0, 0.06);
+		margin: 1.5rem 0 !important;
+		overflow-x: auto;
+	}
+
+	.prose blockquote {
+		border-left: 4px solid var(--color-primary, #f43f5e);
+		padding-left: 1rem;
+		font-style: italic;
+		margin: 1.5rem 0;
+		color: #d1d5db;
+		background: rgba(255, 255, 255, 0.05);
+		padding: 1rem;
+		border-radius: 0.25rem;
+	}
+
+	/* Strengthened selectors for headings to override Tailwind prose defaults */
+	.prose h1,
+	.prose h2,
+	.prose h3,
+	.prose h4,
+	.post-content h1,
+	.post-content h2,
+	.post-content h3,
+	.post-content h4,
+	article .prose h1,
+	article .prose h2,
+	article .prose h3,
+	article .prose h4 {
+		margin-top: 2rem;
+		margin-bottom: 1rem;
+		line-height: 1.3;
+		font-weight: 700;
+		color: var(
+			--color-primary,
+			#f43f5e
+		) !important; /* Added !important to ensure override */
+	}
+
+	.prose h1,
+	.post-content h1 {
+		font-size: 2em;
+		margin-top: 0;
+	}
+
+	.prose h2,
+	.post-content h2 {
+		font-size: 1.7em;
+	}
+
+	.prose h3,
+	.post-content h3 {
+		font-size: 1.4em;
+	}
+
+	.prose h4 {
+		font-size: 1.2em;
+	}
+
+	/* Add subtle reveal animation when the page loads */
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(10px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.post-content {
+		animation: fadeIn 0.6s ease-out;
+	}
+
+	/* Table of Contents Styles */
+	.toc-container {
+		background: rgba(0, 0, 0, 0.2);
+		border: 1px solid rgba(255, 255, 255, 0.1);
+		border-radius: 0.5rem;
+		padding: 1.5rem;
+		margin: 2rem 0;
+		position: relative;
+		box-shadow:
+			0 4px 6px -1px rgba(0, 0, 0, 0.1),
+			0 2px 4px -1px rgba(0, 0, 0, 0.06);
+	}
+
+	.toc-title {
+		font-size: 1.3rem !important;
+		margin-top: 0 !important;
+		margin-bottom: 1rem !important;
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+	}
+
+	.toc-title::before {
+		content: '';
+		display: inline-block;
+		width: 1.2rem;
+		height: 1.2rem;
+		margin-right: 0.5rem;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23F43F5E'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 6h16M4 12h16M4 18h7'%3E%3C/path%3E%3C/svg%3E");
+		background-size: contain;
+		background-repeat: no-repeat;
+	}
+
+	.toc-list {
+		list-style-type: none;
+		padding-left: 0;
+		margin: 0;
+	}
+
+	.toc-item {
+		margin: 0.5rem 0;
+		transition: transform 0.2s ease;
+	}
+
+	.toc-item-h3 {
+		padding-left: 1.5rem;
+		font-size: 0.95em;
+		opacity: 0.9;
+	}
+
+	.toc-link {
+		color: #d1d5db !important;
+		text-decoration: none !important;
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		transition: all 0.2s ease;
+	}
+
+	.toc-link:hover {
+		color: var(--color-primary, #f43f5e) !important;
+		transform: translateX(3px);
+	}
+
+	.toc-link:hover::after {
+		display: none; /* Disable the underline animation for TOC links */
+	}
+
+	.toc-link::before {
+		content: '';
+		display: inline-block;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		background-color: var(--color-primary, #f43f5e);
+		margin-right: 0.5rem;
+		transform: scale(0);
+		transition: transform 0.2s ease;
+	}
+
+	.toc-link:hover::before {
+		transform: scale(1);
+	}
+
+	/* Anchor link styles */
+	.anchor-link {
+		margin-left: 0.5rem;
+		opacity: 0;
+		font-size: 0.8em;
+		transition: opacity 0.2s ease;
+		text-decoration: none !important;
+		color: var(--color-primary, #f43f5e) !important;
+	}
+
+	.heading-custom:hover .anchor-link,
+	.anchor-link.visible {
+		opacity: 0.7;
+	}
+
+	.anchor-link:hover {
+		opacity: 1 !important;
+	}
+
+	.anchor-icon {
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	/* Callout box styles for important content */
+	.callout {
+		border-left: 4px solid var(--color-primary, #f43f5e);
+		background: rgba(255, 255, 255, 0.05);
+		padding: 1.5rem;
+		margin: 2rem 0;
+		border-radius: 0.5rem;
+		box-shadow:
+			0 4px 6px -1px rgba(0, 0, 0, 0.1),
+			0 2px 4px -1px rgba(0, 0, 0, 0.06);
+	}
+
+	.callout-title {
+		font-size: 1.1rem;
+		font-weight: 600;
+		margin-bottom: 0.5rem;
+		color: var(--color-primary, #f43f5e);
+		display: flex;
+		align-items: center;
+	}
+
+	.callout-icon {
+		margin-right: 0.5rem;
+	}
+
+	/* Image caption styles */
+	figure {
+		margin: 2rem 0;
+	}
+
+	figcaption {
+		text-align: center;
+		font-style: italic;
+		color: #d1d5db;
+		font-size: 0.9em;
+		margin-top: 0.75rem;
+		opacity: 0.8;
+	}
+
+	/* Footnote styles */
+	.footnotes {
+		margin-top: 4rem;
+		padding-top: 2rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.1);
+	}
+
+	.footnote-backref {
+		text-decoration: none !important;
+		margin-left: 0.5rem;
+	}
+
+	/* Code block line numbers */
+	pre {
+		counter-reset: line;
+	}
+
+	pre span.line {
+		display: inline-block;
+		width: 100%;
+	}
+
+	pre span.line::before {
+		counter-increment: line;
+		content: counter(line);
+		display: inline-block;
+		width: 1.5rem;
+		margin-right: 1rem;
+		text-align: right;
+		color: rgba(255, 255, 255, 0.4);
+		user-select: none;
+	}
 </style>


### PR DESCRIPTION
This adds custom meta tags to the blog posts so they have better previews when shared. We're using the "slots" functionality to make the default SEO tags in the layout overrideable in a given page.

It does _not_ add the Dublin Core tags because I don't actually know what those are so I left them commented out. 😅

A couple things that aren't here that could be nice-to-have:

1. Descriptions per post. This would need to be added to the content schema / post frontmatter
2. Images. Right now there's no image included, so maybe fall back to the site-wide image or add a custom one to each blog post?


