### PR TITLE
fix: sync lockfile and relax npm engine constraint for CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             },
             "engines": {
                 "node": ">=22 <25",
-                "npm": ">=11.10.0"
+                "npm": ">=10"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -2924,15 +2924,6 @@
                 "sharp": "^0.34.5"
             }
         },
-        "node_modules/@vercel/og/node_modules/css-gradient-parser": {
-            "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
-            "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@vercel/og/node_modules/satori": {
             "version": "0.25.0",
             "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
@@ -2950,37 +2941,6 @@
                 "parse-css-color": "^0.2.1",
                 "postcss-value-parser": "^4.2.0",
                 "yoga-layout": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@vercel/og/node_modules/css-gradient-parser": {
-            "version": "0.0.16",
-            "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
-            "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@vercel/og/node_modules/satori": {
-            "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
-            "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@shuding/opentype.js": "1.4.0-beta.0",
-                "css-background-parser": "^0.1.0",
-                "css-box-shadow": "1.0.0-3",
-                "css-gradient-parser": "^0.0.16",
-                "css-to-react-native": "^3.0.0",
-                "emoji-regex": "^10.2.1",
-                "escape-html": "^1.0.3",
-                "linebreak": "^1.1.0",
-                "parse-css-color": "^0.2.1",
-                "postcss-value-parser": "^4.2.0",
-                "yoga-wasm-web": "^0.3.3"
             },
             "engines": {
                 "node": ">=16"
@@ -4115,12 +4075,6 @@
             "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
         },
         "node_modules/emoji-regex-xs": {
             "version": "2.0.1",
@@ -9972,12 +9926,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
             "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-            "license": "MIT"
-        },
-        "node_modules/yoga-wasm-web": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
-            "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
             "license": "MIT"
         },
         "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
     "name": "ashley.dev",
     "type": "module",
     "version": "1.0.0",
-    "packageManager": "npm@11.12.1",
     "engines": {
         "node": ">=22 <25",
-        "npm": ">=11.10.0"
+        "npm": ">=10"
     },
     "scripts": {
         "dev": "astro dev",


### PR DESCRIPTION
## Problem

The CI workflow on `main` is failing because:

1. **Lockfile out of sync** — `package.json` wants `satori@^0.26.0` but the lockfile had `satori@0.12.2`, causing `npm ci` to fail
2. **npm engine constraint too aggressive** — `engines.npm` required `>=11.10.0`, but Node 22 on GitHub Actions `ubuntu-latest` ships with npm 10.x
3. **`packageManager` field pinned npm@11.12.1** — not available on runners, would cause corepack failures

## Fix

- Regenerated `package-lock.json` so all dependencies resolve correctly (satori now at 0.26.0)
- Relaxed `engines.npm` from `>=11.10.0` to `>=10` to match what's available on ubuntu-latest with Node 22
- Removed the `packageManager` field that pinned npm@11.12.1

No changes to the CI workflow itself — the issue was the lockfile and engine constraints.